### PR TITLE
disconnect from previous room on 'retry'.

### DIFF
--- a/assets/axie-colyseus-demo/scenes/game.scene
+++ b/assets/axie-colyseus-demo/scenes/game.scene
@@ -301,7 +301,7 @@
     "_prefab": null,
     "_lpos": {
       "__type__": "cc.Vec3",
-      "x": 959.9999999999998,
+      "x": 960,
       "y": 540,
       "z": 0
     },
@@ -385,7 +385,7 @@
     "_priority": 0,
     "_fov": 45,
     "_fovAxis": 0,
-    "_orthoHeight": 623.8575667655786,
+    "_orthoHeight": 667.3903966597077,
     "_near": 0,
     "_far": 1000,
     "_color": {
@@ -865,7 +865,7 @@
     "__prefab": null,
     "_contentSize": {
       "__type__": "cc.Size",
-      "width": 1919.9999999999998,
+      "width": 1920,
       "height": 48
     },
     "_anchorPoint": {
@@ -1202,7 +1202,7 @@
     "__prefab": null,
     "_contentSize": {
       "__type__": "cc.Size",
-      "width": 1919.9999999999998,
+      "width": 1920,
       "height": 1080
     },
     "_anchorPoint": {
@@ -1704,7 +1704,7 @@
     },
     "component": "",
     "_componentId": "33e9dGbi/JECJ4e21mNCZbS",
-    "handler": "connect",
+    "handler": "onClickRetry",
     "customEventData": ""
   },
   {
@@ -1747,7 +1747,7 @@
     "__prefab": null,
     "_contentSize": {
       "__type__": "cc.Size",
-      "width": 1919.9999999999998,
+      "width": 1920,
       "height": 1080
     },
     "_anchorPoint": {
@@ -1833,8 +1833,8 @@
     "__prefab": null,
     "_alignFlags": 45,
     "_target": null,
-    "_left": -1.7053025658242404e-13,
-    "_right": -1.7053025658242404e-13,
+    "_left": 5.684341886080802e-14,
+    "_right": 5.684341886080802e-14,
     "_top": 5.684341886080802e-14,
     "_bottom": 5.684341886080802e-14,
     "_horizontalCenter": 0,
@@ -2377,7 +2377,8 @@
     "lightProbeInfo": {
       "__id__": 73
     },
-    "bakedWithStationaryMainLight": false
+    "bakedWithStationaryMainLight": false,
+    "bakedWithHighpLightmap": false
   },
   {
     "__type__": "cc.AmbientInfo",

--- a/assets/axie-colyseus-demo/scripts/GameClient.ts
+++ b/assets/axie-colyseus-demo/scripts/GameClient.ts
@@ -109,6 +109,14 @@ export class GameClient extends Component {
         }
     }
 
+    onClickRetry() {
+      // disconnect from previous room
+      this.room?.leave();
+
+      // connect to new room
+      this.connect();
+    }
+
     onStateChange(state: any) {
         let projectileState = state.projectile;
         if (!projectileState) {


### PR DESCRIPTION
Updated the "retry" button to call a `onClickRetry()` method instead of `connect()`. 

The "retry" method disconnects the client from the previous room before creating a new one. This prevents the client from holding its connection to the previous room when clicking "retry"